### PR TITLE
fix lexer.mll (space) run on windows

### DIFF
--- a/mini-python-ocaml/lexer.mll
+++ b/mini-python-ocaml/lexer.mll
@@ -42,7 +42,7 @@ let letter = ['a'-'z' 'A'-'Z']
 let digit = ['0'-'9']
 let ident = (letter | '_') (letter | digit | '_')*
 let integer = '0' | ['1'-'9'] digit*
-let space = ' ' | '\t'
+let space = ' ' | '\t' | '\r'
 let comment = "#" [^'\n']*
 
 rule next_tokens = parse


### PR DESCRIPTION
add `'\r'` on lexer.mll (space) to fix run on windows problem