### PR TITLE
add gitattributes for run-tests(LF), add parse and type to Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+run-tests text eol=lf

--- a/mini-python-ocaml/Makefile
+++ b/mini-python-ocaml/Makefile
@@ -6,6 +6,12 @@ all: minipython.exe
 tests: minipython.exe
 	bash run-tests "dune exec ./minipython.exe"
 
+parse: minipython.exe
+	./minipython.exe --parse-only test.py
+
+type: minipython.exe
+	./minipython.exe --type-only test.py
+
 minipython.exe:
 	dune build minipython.exe
 


### PR DESCRIPTION
### Changes
1. add `parse` to `Makefile`
2. add `type` to `Makefile`
3. add `.gitattributes` for `run-tests`
### Note
- If your `run-tests` file uses `CRLF` instead of `LF`, click the `1` (`CRLF`) marker in the image and select `2` (`LF`).
![image](https://github.com/user-attachments/assets/38588ee8-18c5-4c7b-9a19-8842cbcbf852)